### PR TITLE
unzip lisp.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ A cat program that doesn't terminate on EOF:
 ```
 $ git clone https://github.com/kspalaiologos/malbolge-lisp
 $ cd malbolge-lisp
-$ unzip lisp.mb
+$ unzip lisp.zip
 $ clang -O3 -march=native fast20.c -o fast20
 $ cat init_module.mb core.mb > lisp.mb
 $ ./fast20 lisp.mb


### PR DESCRIPTION
The README instructions are slightly wrong, as they currently ask to unzip lisp.mb instead of the correct lisp.zip. This PR corrects that.